### PR TITLE
feat: add guest order form access

### DIFF
--- a/public/menu.pdf
+++ b/public/menu.pdf
@@ -1,0 +1,21 @@
+%PDF-1.1
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R/Resources<</Font<</F1 5 0 R>>>>>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 24 Tf 72 720 Td (Sample Menu) Tj ET
+endstream
+endobj
+5 0 obj<</Type/Font/Subtype/Type1/BaseFont/Helvetica>>endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000053 00000 n 
+0000000102 00000 n 
+0000000203 00000 n 
+0000000297 00000 n 
+trailer<</Size 6/Root 1 0 R>>
+startxref
+361
+%%EOF

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from "react";
 import { HashRouter as Router, Routes, Route, Navigate, useNavigate } from "react-router-dom";
+import OrderFormPage from "./components/pages/order-form";
 import { AuthProvider } from "./lib/contexts/auth-context";
 import { LanguageProvider } from "./lib/contexts/language-context";
 import { ProtectedRoute } from "./components/auth/protected-route";
@@ -120,63 +121,77 @@ function AppContent() {
 
   return (
     <Router>
-      <ProtectedRoute>
-        <EnhancedAppLayout onUserChange={handleUserChange}>
-          <Routes>
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={
-              <Dashboard 
-                onTaskClick={handleTaskClick}
-                onCreateTask={handleCreateTask}
-                onCreateDiscipline={handleCreateDiscipline}
-                onNewOrder={handleNewOrder}
-                onCashCount={handleCashCount}
-                onStaffMeal={handleStaffMeal}
-                onReportIssue={handleReportIssue}
-                onClockIn={handleClockIn}
-                onRequestMeal={onRequestMeal}
-                onTakeBreak={onTakeBreak}
-                onGetHelp={onGetHelp}
-              />
-            } />
-            <Route path="/tasks" element={
-              <Tasks
-                tasks={tasks}
-                onTaskClick={handleTaskClick}
-                onCreateTask={handleCreateTask}
-                onCreateDiscipline={handleCreateDiscipline}
-              />
-            } />
-            <Route path="/task-management" element={<TaskManagementDemo />} />
-            <Route path="/leaderboard" element={<Leaderboard />} />
-            <Route path="/staff" element={<Staff onProfileClick={handleProfileClick} />} />
-            <Route path="/recipes" element={<Recipes />} />
-            <Route path="/staff-meal" element={<StaffMealPage />} />
-            <Route path="/disposal" element={<DisposalPage />} />
-            <Route path="/issues" element={<IssuesPage />} />
-            <Route path="/purchase-list" element={<PurchaseListPage />} />
-            <Route path="/skills" element={<SkillsPage />} />
-            <Route path="/suppliers" element={<SuppliersPage />} />
-            <Route path="/salary" element={<SalaryPage />} />
-            <Route path="/online-orders" element={<OnlineOrdersPage />} />
-            <Route path="/cash" element={<CashPage />} />
-            <Route path="/reports" element={<ReportsPage />} />
-            <Route path="*" element={<Navigate to="/dashboard" replace />} />
-          </Routes>
-        </EnhancedAppLayout>
+      <Routes>
+        <Route path="/order-form" element={<OrderFormPage />} />
+        <Route
+          path="/*"
+          element={
+            <ProtectedRoute>
+              <EnhancedAppLayout onUserChange={handleUserChange}>
+                <Routes>
+                  <Route path="/" element={<Navigate to="/dashboard" replace />} />
+                  <Route
+                    path="/dashboard"
+                    element={
+                      <Dashboard
+                        onTaskClick={handleTaskClick}
+                        onCreateTask={handleCreateTask}
+                        onCreateDiscipline={handleCreateDiscipline}
+                        onNewOrder={handleNewOrder}
+                        onCashCount={handleCashCount}
+                        onStaffMeal={handleStaffMeal}
+                        onReportIssue={handleReportIssue}
+                        onClockIn={handleClockIn}
+                        onRequestMeal={onRequestMeal}
+                        onTakeBreak={onTakeBreak}
+                        onGetHelp={onGetHelp}
+                      />
+                    }
+                  />
+                  <Route
+                    path="/tasks"
+                    element={
+                      <Tasks
+                        tasks={tasks}
+                        onTaskClick={handleTaskClick}
+                        onCreateTask={handleCreateTask}
+                        onCreateDiscipline={handleCreateDiscipline}
+                      />
+                    }
+                  />
+                  <Route path="/task-management" element={<TaskManagementDemo />} />
+                  <Route path="/leaderboard" element={<Leaderboard />} />
+                  <Route path="/staff" element={<Staff onProfileClick={handleProfileClick} />} />
+                  <Route path="/recipes" element={<Recipes />} />
+                  <Route path="/staff-meal" element={<StaffMealPage />} />
+                  <Route path="/disposal" element={<DisposalPage />} />
+                  <Route path="/issues" element={<IssuesPage />} />
+                  <Route path="/purchase-list" element={<PurchaseListPage />} />
+                  <Route path="/skills" element={<SkillsPage />} />
+                  <Route path="/suppliers" element={<SuppliersPage />} />
+                  <Route path="/salary" element={<SalaryPage />} />
+                  <Route path="/online-orders" element={<OnlineOrdersPage />} />
+                  <Route path="/cash" element={<CashPage />} />
+                  <Route path="/reports" element={<ReportsPage />} />
+                  <Route path="*" element={<Navigate to="/dashboard" replace />} />
+                </Routes>
+              </EnhancedAppLayout>
 
-        <TaskDetailModal
-          task={selectedTask}
-          isOpen={isTaskModalOpen}
-          onClose={() => {
-            setIsTaskModalOpen(false);
-            setSelectedTask(null);
-          }}
-          onUpdate={handleTaskUpdate}
+              <TaskDetailModal
+                task={selectedTask}
+                isOpen={isTaskModalOpen}
+                onClose={() => {
+                  setIsTaskModalOpen(false);
+                  setSelectedTask(null);
+                }}
+                onUpdate={handleTaskUpdate}
+              />
+
+              <Toaster />
+            </ProtectedRoute>
+          }
         />
-
-        <Toaster />
-      </ProtectedRoute>
+      </Routes>
     </Router>
   );
 }

--- a/src/components/pages/online-orders.tsx
+++ b/src/components/pages/online-orders.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { useState, useMemo } from 'react';
+import { Link } from 'react-router-dom';
 import { 
   Search, 
   Filter,
@@ -209,14 +210,17 @@ export function OnlineOrdersPage() {
       <div className="space-y-6">
         {/* Header */}
         <div className="flex flex-col gap-4">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-2xl font-bold">Online Orders</h1>
-              <p className="text-muted-foreground">
-                Manage customer orders from all platforms
-              </p>
-            </div>
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-bold">Online Orders</h1>
+            <p className="text-muted-foreground">
+              Manage customer orders from all platforms
+            </p>
           </div>
+          <Button asChild variant="outline">
+            <Link to="/order-form">View Order form as Guest</Link>
+          </Button>
+        </div>
 
           {/* Filters */}
           <div className="flex flex-col md:flex-row gap-4">

--- a/src/components/pages/order-form.tsx
+++ b/src/components/pages/order-form.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { useState } from "react";
+import { Input } from "../ui/input";
+import { Textarea } from "../ui/textarea";
+import { Label } from "../ui/label";
+import { Button } from "../ui/button";
+import { toast } from "sonner@2.0.3";
+
+export function OrderFormPage() {
+  const [orderCode, setOrderCode] = useState("");
+  const [itemName, setItemName] = useState("");
+  const [remarks, setRemarks] = useState("");
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    toast.success("Order submitted!");
+    setOrderCode("");
+    setItemName("");
+    setRemarks("");
+  };
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-6">
+      <h1 className="text-2xl font-bold">Order Form</h1>
+      <div className="w-full h-96 border">
+        <iframe src="/menu.pdf" title="Menu" className="w-full h-full" />
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div className="space-y-2">
+          <Label htmlFor="orderCode">Order Code</Label>
+          <Input
+            id="orderCode"
+            value={orderCode}
+            onChange={(e) => setOrderCode(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="itemName">Order Item Name</Label>
+          <Input
+            id="itemName"
+            value={itemName}
+            onChange={(e) => setItemName(e.target.value)}
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="remarks">Remark</Label>
+          <Textarea
+            id="remarks"
+            value={remarks}
+            onChange={(e) => setRemarks(e.target.value)}
+          />
+        </div>
+        <Button type="submit" className="w-full">
+          Submit Order
+        </Button>
+      </form>
+    </div>
+  );
+}
+
+export default OrderFormPage;


### PR DESCRIPTION
## Summary
- add "View Order form as Guest" link on online orders page
- create new order form page with menu pdf and input fields
- expose order form route outside authentication and include sample menu pdf

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: vite: not found)


------
https://chatgpt.com/codex/tasks/task_e_68ad023733c08329925c2be3c7a01ae8