### PR TITLE
refactor: use current user hook across app

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -47,7 +47,8 @@ import {
   SheetTrigger,
 } from '../ui/sheet';
 import { ScrollArea } from '../ui/scroll-area';
-import { currentUser, users } from '../../lib/data';
+import { users } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { getUnreadCount } from '../../lib/notifications-data';
 import { Language } from '../../lib/types';
 
@@ -99,6 +100,7 @@ export function AppLayout({
   const [mounted, setMounted] = useState(false);
   const [isMoreMenuOpen, setIsMoreMenuOpen] = useState(false);
   const [notificationCount, setNotificationCount] = useState(0);
+  const { user: currentUser, isLoading } = useCurrentUser();
 
   useEffect(() => {
     setMounted(true);
@@ -121,9 +123,9 @@ export function AppLayout({
     return () => clearInterval(interval);
   }, []);
 
-  // Don't render until mounted to avoid hydration issues
-  if (!mounted) {
-    return <div className="h-screen bg-background" />; 
+  // Don't render until mounted and user loaded to avoid hydration issues
+  if (!mounted || isLoading || !currentUser) {
+    return <div className="h-screen bg-background" />;
   }
 
   const isManagement = currentUser.roles.some(role => 

--- a/src/components/layout/enhanced-app-layout.tsx
+++ b/src/components/layout/enhanced-app-layout.tsx
@@ -64,7 +64,8 @@ import {
 import { ScrollArea } from '../ui/scroll-area';
 import { Separator } from '../ui/separator';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
-import { currentUser, users } from '../../lib/data';
+import { users } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { getUnreadCount } from '../../lib/notifications-data';
 import { useTranslations } from '../../lib/hooks/use-translations';
 
@@ -89,6 +90,7 @@ export function EnhancedAppLayout({
   const [expandedGroups, setExpandedGroups] = useState<string[]>(['operations']); // Operations expanded by default
   const [pinnedItems, setPinnedItems] = useState<string[]>(['dashboard', 'online-orders', 'cash']); // Default pinned items
   const [recentItems, setRecentItems] = useState<string[]>(['tasks', 'staff']);
+  const { user: currentUser, isLoading } = useCurrentUser();
 
   // Navigation groups with logical organization
   const navigationGroups = [
@@ -211,9 +213,9 @@ export function EnhancedAppLayout({
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, []);
 
-  // Don't render until mounted to avoid hydration issues
-  if (!mounted) {
-    return <div className="h-screen bg-background" />; 
+  // Don't render until mounted and user loaded to avoid hydration issues
+  if (!mounted || isLoading || !currentUser) {
+    return <div className="h-screen bg-background" />;
   }
 
   const isManagement = currentUser.roles.some(role => 

--- a/src/components/modals/recipe-create-modal.tsx
+++ b/src/components/modals/recipe-create-modal.tsx
@@ -18,7 +18,7 @@ import { Checkbox } from '../ui/checkbox';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Badge } from '../ui/badge';
 import { Recipe, RecipeIngredient, RecipeStep, RecipeAttachment, Station } from '../../lib/recipes-data';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { toast } from "sonner@2.0.3";
 
 interface RecipeCreateModalProps {
@@ -28,6 +28,7 @@ interface RecipeCreateModalProps {
 }
 
 export function RecipeCreateModal({ isOpen, onClose, onCreateRecipe }: RecipeCreateModalProps) {
+  useCurrentUser();
   const [formData, setFormData] = useState({
     name: '',
     category: 'main-dish' as 'main-dish' | 'soup' | 'beverage' | 'sauce-condiment',

--- a/src/components/modals/recipe-edit-modal.tsx
+++ b/src/components/modals/recipe-edit-modal.tsx
@@ -18,7 +18,7 @@ import { Checkbox } from '../ui/checkbox';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Badge } from '../ui/badge';
 import { Recipe, RecipeIngredient, RecipeStep, RecipeAttachment, Station } from '../../lib/recipes-data';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { toast } from "sonner@2.0.3";
 
 interface RecipeEditModalProps {
@@ -29,6 +29,7 @@ interface RecipeEditModalProps {
 }
 
 export function RecipeEditModal({ isOpen, onClose, onUpdateRecipe, recipe }: RecipeEditModalProps) {
+  useCurrentUser();
   const [formData, setFormData] = useState({
     name: '',
     category: 'main-dish' as 'main-dish' | 'soup' | 'beverage' | 'sauce-condiment',

--- a/src/components/modals/task-create-modal.tsx
+++ b/src/components/modals/task-create-modal.tsx
@@ -17,7 +17,8 @@ import {
 import { Switch } from '../ui/switch';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Task, Station, User as UserType } from '../../lib/types';
-import { users, currentUser } from '../../lib/data';
+import { users } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 
 interface TaskCreateModalProps {
   isOpen: boolean;
@@ -44,6 +45,12 @@ export function TaskCreateModal({ isOpen, onClose, onCreateTask }: TaskCreateMod
   const stations: Station[] = ['kitchen', 'front', 'store', 'outdoor'];
   const proofTypes = ['none', 'photo', 'text', 'checklist'];
   const repeatOptions = ['', 'daily', 'weekly', 'monthly', 'custom'];
+
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return null;
+  }
 
   const validateForm = () => {
     const newErrors: Record<string, string> = {};

--- a/src/components/modals/task-detail-modal.tsx
+++ b/src/components/modals/task-detail-modal.tsx
@@ -27,7 +27,8 @@ import { Progress } from '../ui/progress';
 import { Separator } from '../ui/separator';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Task } from '../../lib/types';
-import { users, currentUser, managementBudgets, appSettings } from '../../lib/data';
+import { users, managementBudgets, appSettings } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 
 interface TaskDetailModalProps {
   task: Task | null;
@@ -43,17 +44,18 @@ export function TaskDetailModal({ task, isOpen, onClose, onTaskUpdate }: TaskDet
   const [showApproval, setShowApproval] = useState(false);
   const [showRejection, setShowRejection] = useState(false);
   const [proofText, setProofText] = useState('');
+  const { user: currentUser, isLoading } = useCurrentUser();
 
-  if (!task) return null;
+  if (!task || isLoading || !currentUser) return null;
 
   const assignee = task.assigneeId ? users.find(u => u.id === task.assigneeId) : null;
   const assigner = users.find(u => u.id === task.assignerId);
-  
+
   const isAssignee = task.assigneeId === currentUser.id;
-  const canApprove = task.status === 'pending-review' && 
-    (task.assignerId === currentUser.id || 
+  const canApprove = task.status === 'pending-review' &&
+    (task.assignerId === currentUser.id ||
      currentUser.roles.some(role => ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)));
-  
+
   const isOwner = currentUser.roles.includes('owner');
   const canClaim = task.status === 'open' && 
     (isOwner ? assigner?.roles.includes('owner') : true);

--- a/src/components/modals/task-edit-modal.tsx
+++ b/src/components/modals/task-edit-modal.tsx
@@ -16,7 +16,8 @@ import {
 } from '../ui/select';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Task, Station, TaskStatus } from '../../lib/types';
-import { users, currentUser } from '../../lib/data';
+import { users } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 
 interface TaskEditModalProps {
   task: Task | null;
@@ -48,6 +49,12 @@ export function TaskEditModal({ task, isOpen, onClose, onTaskUpdate, onTaskDelet
   const statuses: TaskStatus[] = ['open', 'in-progress', 'on-hold', 'pending-review', 'overdue', 'done'];
   const proofTypes = ['none', 'photo', 'text', 'checklist'];
   const repeatOptions = ['', 'daily', 'weekly', 'monthly', 'custom'];
+
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return null;
+  }
 
   // Update form data when task changes
   useEffect(() => {

--- a/src/components/pages/cash.tsx
+++ b/src/components/pages/cash.tsx
@@ -55,7 +55,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Separator } from '../ui/separator';
 import { ScrollArea } from '../ui/scroll-area';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
-import { currentUser } from '../../lib/data';
+import { useCurrentUserWithFallback } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { 
   cashReconciliations,
@@ -89,6 +89,7 @@ import {
 } from '../../lib/cash-export';
 
 export function CashPage() {
+  const { user: currentUser } = useCurrentUserWithFallback();
   const [activeTab, setActiveTab] = useState('reconciliation');
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
   const [selectedShift, setSelectedShift] = useState<string>('');

--- a/src/components/pages/disposal.tsx
+++ b/src/components/pages/disposal.tsx
@@ -45,7 +45,7 @@ import {
   DialogHeader,
   DialogTitle
 } from '../ui/dialog';
-import { currentUser } from '../../lib/data';
+import { useCurrentUserWithFallback } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import {
   disposals,
@@ -67,6 +67,8 @@ export function DisposalPage() {
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
   const [disposalList, setDisposalList] = useState<Disposal[]>(() => [...disposals]);
+
+  const { user: currentUser } = useCurrentUserWithFallback();
 
   // Form state
   const [formData, setFormData] = useState({

--- a/src/components/pages/issues.tsx
+++ b/src/components/pages/issues.tsx
@@ -52,7 +52,7 @@ import {
   DialogTitle
 } from '../ui/dialog';
 import { Separator } from '../ui/separator';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { managementBudgets } from '../../lib/data';
 import { 
@@ -75,6 +75,8 @@ export function IssuesPage() {
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [isApprovalOpen, setIsApprovalOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+
+  const { user: currentUser, isLoading } = useCurrentUser();
 
   // Form state
   const [formData, setFormData] = useState({
@@ -100,7 +102,11 @@ export function IssuesPage() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/leaderboard.tsx
+++ b/src/components/pages/leaderboard.tsx
@@ -44,7 +44,7 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from '../ui/tooltip';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { appSettings } from '../../lib/data';
 import { leaderboardData, getUserRank, getTotalActiveUsers, baharMonthlyRank } from '../../lib/leaderboard-data';
 import { UserRole, Station } from '../../lib/types';
@@ -64,13 +64,19 @@ export function Leaderboard({ onAdminClick, onProfileClick }: LeaderboardProps) 
   const [selectedStation, setSelectedStation] = useState<string>('all');
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
   React.useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/online-orders.tsx
+++ b/src/components/pages/online-orders.tsx
@@ -53,7 +53,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Separator } from '../ui/separator';
 import { ScrollArea } from '../ui/scroll-area';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { 
   onlineOrders,
@@ -77,12 +77,17 @@ import {
 import { toast } from "sonner@2.0.3";
 
 export function OnlineOrdersPage() {
+  const { user: currentUser, isLoading } = useCurrentUser();
   const [searchTerm, setSearchTerm] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [platformFilter, setPlatformFilter] = useState<string>('all');
   const [selectedOrder, setSelectedOrder] = useState<OnlineOrder | null>(null);
   const [isOrderModalOpen, setIsOrderModalOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
 
   React.useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
@@ -216,6 +221,7 @@ export function OnlineOrdersPage() {
             <p className="text-muted-foreground">
               Manage customer orders from all platforms
             </p>
+            <p className="text-sm text-muted-foreground">Welcome back, {currentUser.name}</p>
           </div>
           <Button asChild variant="outline">
             <Link to="/order-form">View Order form as Guest</Link>

--- a/src/components/pages/purchase-list.tsx
+++ b/src/components/pages/purchase-list.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo } from 'react';
 import { Plus, ShoppingCart } from 'lucide-react';
 import { Button } from '../ui/button';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { PurchaseStats } from './purchase-list/purchase-stats';
 import { PurchaseFilters } from './purchase-list/purchase-filters';
 import { PurchaseItemCard } from './purchase-list/purchase-item-card';
@@ -56,7 +56,13 @@ export function PurchaseListPage() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/recipes.tsx
+++ b/src/components/pages/recipes.tsx
@@ -71,7 +71,7 @@ import {
 } from '../ui/dialog';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Separator } from '../ui/separator';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import {
   scaleRecipe,
   getCategoryDisplayName,
@@ -118,6 +118,8 @@ export function Recipes({}: RecipesProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [recipesList, setRecipesList] = useState<Recipe[]>([]);
 
+  const { user: currentUser, isLoading: userLoading } = useCurrentUser();
+
   React.useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
@@ -140,7 +142,11 @@ export function Recipes({}: RecipesProps) {
     fetchRecipes();
   }, [refreshTrigger]);
 
-  const isManagement = currentUser.roles.some(role => 
+  if (userLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen'].includes(role)
   );
 

--- a/src/components/pages/reports.tsx
+++ b/src/components/pages/reports.tsx
@@ -40,7 +40,7 @@ import { Badge } from '../ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import { Separator } from '../ui/separator';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 
 // Sample data for charts
 const disposalData = [
@@ -116,7 +116,13 @@ export function ReportsPage() {
   const [selectedMetric, setSelectedMetric] = useState('all');
   const [dateRange, setDateRange] = useState('last8weeks');
 
-  const isManagement = currentUser.roles.some(role => 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/salary.tsx
+++ b/src/components/pages/salary.tsx
@@ -53,7 +53,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Separator } from '../ui/separator';
 import { Progress } from '../ui/progress';
-import { currentUser } from '../../lib/data';
+import { useCurrentUserWithFallback } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { 
   overtimeRecords,
@@ -81,6 +81,7 @@ import {
 import { toast } from "sonner";
 
 export function SalaryPage() {
+  const { user: currentUser } = useCurrentUserWithFallback();
   const [activeTab, setActiveTab] = useState('overview');
   const [selectedStaff, setSelectedStaff] = useState<string>(currentUser.id);
   const [dateRange, setDateRange] = useState({

--- a/src/components/pages/skills.tsx
+++ b/src/components/pages/skills.tsx
@@ -64,7 +64,8 @@ import {
 import { Progress } from '../ui/progress';
 import { Separator } from '../ui/separator';
 import { Switch } from '../ui/switch';
-import { currentUser, managementBudgets } from '../../lib/data';
+import { managementBudgets } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { 
   skills,
@@ -118,7 +119,13 @@ export function SkillsPage() {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/staff-meal.tsx
+++ b/src/components/pages/staff-meal.tsx
@@ -52,7 +52,7 @@ import {
 } from '../ui/dialog';
 import { Separator } from '../ui/separator';
 import { Alert, AlertDescription } from '../ui/alert';
-import { currentUser } from '../../lib/data';
+import { useCurrentUserWithFallback } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { 
   staffMeals, 
@@ -77,6 +77,8 @@ export function StaffMealPage({}: StaffMealProps) {
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
   const [showQuickEntry, setShowQuickEntry] = useState(false);
+
+  const { user: currentUser } = useCurrentUserWithFallback();
 
   // Form state
   const [formData, setFormData] = useState({

--- a/src/components/pages/staff.tsx
+++ b/src/components/pages/staff.tsx
@@ -65,7 +65,7 @@ import {
 } from '../ui/dialog';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Separator } from '../ui/separator';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import {
   staffMembers,
   getStaffMemberById,
@@ -114,13 +114,19 @@ export function Staff({ onDisciplineClick }: StaffProps) {
   const [addForm, setAddForm] = useState<Partial<StaffMember>>(initialAddForm);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
   React.useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/suppliers.tsx
+++ b/src/components/pages/suppliers.tsx
@@ -61,7 +61,7 @@ import {
 } from '../ui/dropdown-menu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Separator } from '../ui/separator';
-import { currentUser } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { staffMembers } from '../../lib/staff-data';
 import { 
   suppliers,
@@ -117,13 +117,19 @@ export function SuppliersPage() {
 
   const [productInput, setProductInput] = useState('');
 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
   React.useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768);
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/pages/tasks.tsx
+++ b/src/components/pages/tasks.tsx
@@ -54,7 +54,8 @@ import { Label } from '../ui/label';
 import { Separator } from '../ui/separator';
 import { Alert, AlertDescription } from '../ui/alert';
 import { Task, Station, TaskStatus, User as UserType } from '../../lib/types';
-import { users, currentUser } from '../../lib/data';
+import { users } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 
 interface TasksProps {
   tasks: Task[];
@@ -99,7 +100,13 @@ export function Tasks({
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
-  const isManagement = currentUser.roles.some(role => 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 

--- a/src/components/task-management/task-list.tsx
+++ b/src/components/task-management/task-list.tsx
@@ -46,7 +46,8 @@ import {
 import { StatusChip } from '../ui/status-chip';
 import { Avatar, AvatarImage, AvatarFallback } from '../ui/avatar';
 import { Task, Station, TaskStatus, User as UserType } from '../../lib/types';
-import { users, currentUser } from '../../lib/data';
+import { users } from '../../lib/data';
+import { useCurrentUser } from '../../lib/hooks/use-current-user';
 import { TaskCreateModal } from '../modals/task-create-modal';
 import { TaskEditModal } from '../modals/task-edit-modal';
 import { TaskDetailModal } from '../modals/task-detail-modal';
@@ -105,7 +106,13 @@ export function TaskList({ tasks, onTasksChange }: TaskListProps) {
     setFilteredTasks(filtered);
   }, [tasks, selectedStatus, selectedStation, selectedAssignee, selectedAssigner, repeatOnly, searchQuery]);
 
-  const isManagement = currentUser.roles.some(role => 
+  const { user: currentUser, isLoading } = useCurrentUser();
+
+  if (isLoading || !currentUser) {
+    return <div>Loading...</div>;
+  }
+
+  const isManagement = currentUser.roles.some(role =>
     ['owner', 'manager', 'head-of-kitchen', 'front-desk-manager'].includes(role)
   );
 


### PR DESCRIPTION
## Summary
- replace deprecated `currentUser` imports with `useCurrentUser` or `useCurrentUserWithFallback`
- handle loading states for user-dependent views

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Transform failed with 4 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ad0c0a373c8329a3cf297dcc214474