### PR TITLE
feat: add skill verification workflow

### DIFF
--- a/database/init/01-schema.sql
+++ b/database/init/01-schema.sql
@@ -220,27 +220,41 @@ CREATE TABLE notifications (
     read_at TIMESTAMP WITH TIME ZONE
 );
 
--- Skills Matrix table
+-- Skills table
 CREATE TABLE skills (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    name VARCHAR(255) NOT NULL,
-    category VARCHAR(100),
+    name VARCHAR(255) NOT NULL UNIQUE,
+    category VARCHAR(100) NOT NULL,
     description TEXT,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
--- User Skills table (many-to-many)
+-- User skills table
 CREATE TABLE user_skills (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    user_id UUID NOT NULL REFERENCES users(id),
-    skill_id UUID NOT NULL REFERENCES skills(id),
-    proficiency_level INTEGER CHECK (proficiency_level >= 1 AND proficiency_level <= 5),
-    certified BOOLEAN DEFAULT false,
-    certification_date DATE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    skill_id UUID NOT NULL REFERENCES skills(id) ON DELETE CASCADE,
+    level VARCHAR(20) NOT NULL,
+    verified BOOLEAN DEFAULT false,
+    verified_by UUID REFERENCES users(id),
+    verified_date DATE,
+    requested_verification BOOLEAN DEFAULT false,
+    is_exclusive BOOLEAN DEFAULT false,
     notes TEXT,
+    points_awarded INTEGER DEFAULT 0,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(user_id, skill_id)
+);
+
+-- Point entries table
+CREATE TABLE point_entries (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    points INTEGER NOT NULL,
+    reason VARCHAR(255),
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Salary Records table
@@ -290,9 +304,11 @@ CREATE TRIGGER update_recipes_updated_at BEFORE UPDATE ON recipes
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_online_orders_updated_at BEFORE UPDATE ON online_orders 
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_suppliers_updated_at BEFORE UPDATE ON suppliers 
+CREATE TRIGGER update_suppliers_updated_at BEFORE UPDATE ON suppliers
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_issues_updated_at BEFORE UPDATE ON issues 
+CREATE TRIGGER update_issues_updated_at BEFORE UPDATE ON issues
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_user_skills_updated_at BEFORE UPDATE ON user_skills 
+CREATE TRIGGER update_skills_updated_at BEFORE UPDATE ON skills
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+CREATE TRIGGER update_user_skills_updated_at BEFORE UPDATE ON user_skills
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/src/components/pages/skills.tsx
+++ b/src/components/pages/skills.tsx
@@ -96,6 +96,8 @@ export function SkillsPage() {
   const [selectedStaffSkill, setSelectedStaffSkill] = useState<StaffSkill | null>(null);
   const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
+  const skillAwardDefault = 50;
+
   // Form state
   const [addSkillForm, setAddSkillForm] = useState({
     staffId: '',
@@ -272,26 +274,33 @@ export function SkillsPage() {
   const handleVerifySkill = () => {
     if (!selectedStaffSkill) return;
 
-    const budgetNeeded = 50;
-    if (!selectedStaffSkill.verified && budgetNeeded > currentBudget) {
-      toast.error(`Insufficient budget. You have RM${currentBudget} remaining today.`);
-      return;
-    }
-
     const updated = updateStaffSkill(selectedStaffSkill.id, {
       verified: true,
       verifiedBy: currentUser.id,
       verifiedDate: new Date().toISOString().split('T')[0],
-      pointsAwarded: selectedStaffSkill.verified ? selectedStaffSkill.pointsAwarded : 50,
+      pointsAwarded: selectedStaffSkill.verified ? selectedStaffSkill.pointsAwarded : skillAwardDefault,
       requestedVerification: false
     });
 
     if (updated) {
       const staff = staffMembers.find(s => s.id === selectedStaffSkill.staffId);
-      toast.success(`Skill verified! +50 points awarded to ${staff?.name}`);
+      toast.success(`Skill verified! +${skillAwardDefault} points awarded to ${staff?.name}`);
       setIsVerificationOpen(false);
     } else {
       toast.error('Failed to verify skill');
+    }
+  };
+
+  const handleDenyVerification = (skill?: StaffSkill) => {
+    const target = skill || selectedStaffSkill;
+    if (!target) return;
+    const updated = updateStaffSkill(target.id, { requestedVerification: false });
+    if (updated) {
+      const staff = staffMembers.find(s => s.id === target.staffId);
+      toast.info(`Verification request denied for ${target.skillName} - ${staff?.name}`);
+      setIsVerificationOpen(false);
+    } else {
+      toast.error('Failed to update skill');
     }
   };
 
@@ -531,12 +540,21 @@ export function SkillsPage() {
                                         </DropdownMenuTrigger>
                                         <DropdownMenuContent>
                                           {!skill.verified && (
-                                            <DropdownMenuItem onClick={() => {
-                                              setSelectedStaffSkill(skill);
-                                              setIsVerificationOpen(true);
-                                            }}>
-                                              Verify Skill
-                                            </DropdownMenuItem>
+                                            <>
+                                              <DropdownMenuItem
+                                                onClick={() => {
+                                                  setSelectedStaffSkill(skill);
+                                                  setIsVerificationOpen(true);
+                                                }}
+                                              >
+                                                {skill.requestedVerification ? 'Review Request' : 'Verify Skill'}
+                                              </DropdownMenuItem>
+                                              {skill.requestedVerification && (
+                                                <DropdownMenuItem onClick={() => handleDenyVerification(skill)}>
+                                                  Deny Request
+                                                </DropdownMenuItem>
+                                              )}
+                                            </>
                                           )}
                                           <DropdownMenuItem onClick={() => handleEditSkill(skill)}>
                                             Edit Skill
@@ -616,9 +634,24 @@ export function SkillsPage() {
                                             {staffSkill.verified ? (
                                               <CheckCircle className="size-3 text-success" />
                                             ) : staffSkill.requestedVerification ? (
-                                              <Clock className="size-3 text-warning" />
+                                              isManagement ? (
+                                                <Button
+                                                  size="sm"
+                                                  variant="ghost"
+                                                  className="h-6 px-2 text-xs"
+                                                  onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    setSelectedStaffSkill(staffSkill);
+                                                    setIsVerificationOpen(true);
+                                                  }}
+                                                >
+                                                  Review
+                                                </Button>
+                                              ) : (
+                                                <Clock className="size-3 text-warning" />
+                                              )
                                             ) : (
-                                              isManagement && (
+                                              isManagement ? (
                                                 <Button
                                                   size="sm"
                                                   variant="ghost"
@@ -631,6 +664,20 @@ export function SkillsPage() {
                                                 >
                                                   Verify
                                                 </Button>
+                                              ) : (
+                                                staff.id === currentUser.id && (
+                                                  <Button
+                                                    size="sm"
+                                                    variant="ghost"
+                                                    className="h-6 px-2 text-xs"
+                                                    onClick={(e) => {
+                                                      e.stopPropagation();
+                                                      handleRequestVerification(staff.id, skill.name);
+                                                    }}
+                                                  >
+                                                    Request
+                                                  </Button>
+                                                )
                                               )
                                             )}
                                           </div>
@@ -701,7 +748,7 @@ export function SkillsPage() {
                 </div>
                 <Progress value={(currentBudget / 500) * 100} className="h-2" />
                 <div className="text-xs text-muted-foreground">
-                  Each skill verification awards +50 points and consumes budget
+                  Each skill verification awards +{skillAwardDefault} points without affecting budget
                 </div>
               </div>
             </CardContent>
@@ -779,7 +826,7 @@ export function SkillsPage() {
                 checked={addSkillForm.verified}
                 onCheckedChange={(checked) => setAddSkillForm(prev => ({ ...prev, verified: checked }))}
               />
-              <Label htmlFor="verified">Verified (awards +50 points)</Label>
+              <Label htmlFor="verified">Verified (awards +{skillAwardDefault} points)</Label>
             </div>
 
             <div className="flex items-center space-x-2">
@@ -806,15 +853,11 @@ export function SkillsPage() {
 
             {addSkillForm.verified && (
               <div className="space-y-2">
-                <Label className="text-sm">Budget Impact</Label>
+                <Label className="text-sm">Verification Award</Label>
                 <div className="bg-muted p-3 rounded-lg">
                   <div className="flex justify-between text-sm">
                     <span>Points Award:</span>
-                    <span className="font-semibold text-green-600">+50</span>
-                  </div>
-                  <div className="flex justify-between text-sm">
-                    <span>Budget Remaining:</span>
-                    <span className="font-semibold">RM{currentBudget} / RM500</span>
+                    <span className="font-semibold text-green-600">+{skillAwardDefault}</span>
                   </div>
                 </div>
               </div>
@@ -941,11 +984,7 @@ export function SkillsPage() {
               <div className="space-y-2">
                 <div className="flex justify-between">
                   <span>Points Award:</span>
-                  <span className="font-semibold text-green-600">+50</span>
-                </div>
-                <div className="flex justify-between">
-                  <span>Budget Remaining:</span>
-                  <span className="font-semibold">RM{currentBudget} / RM500</span>
+                  <span className="font-semibold text-green-600">+{skillAwardDefault}</span>
                 </div>
               </div>
 
@@ -961,6 +1000,9 @@ export function SkillsPage() {
           <DialogFooter>
             <Button variant="outline" onClick={() => setIsVerificationOpen(false)}>
               Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => handleDenyVerification()}>
+              Deny
             </Button>
             <Button onClick={handleVerifySkill}>
               <Award className="size-4 mr-1" />

--- a/src/lib/services/index.ts
+++ b/src/lib/services/index.ts
@@ -2,3 +2,6 @@ export * from './users.service';
 export * from './tasks.service';
 export * from './recipes.service';
 export * from './suppliers.service';
+export * from './skills.service';
+export * from './user-skills.service';
+export * from './point-entries.service';

--- a/src/lib/services/point-entries.service.ts
+++ b/src/lib/services/point-entries.service.ts
@@ -1,0 +1,14 @@
+import { query } from '../database';
+import { PointEntry } from '../types';
+
+export class PointEntriesService {
+  async create(entry: Omit<PointEntry, 'id' | 'createdAt'>): Promise<PointEntry> {
+    const result = await query(
+      `INSERT INTO point_entries (user_id, points, reason) VALUES ($1,$2,$3) RETURNING id, user_id as "userId", points, reason, created_at as "createdAt"`,
+      [entry.userId, entry.points, entry.reason]
+    );
+    return result.rows[0];
+  }
+}
+
+export default PointEntriesService;

--- a/src/lib/services/skills.service.ts
+++ b/src/lib/services/skills.service.ts
@@ -1,0 +1,62 @@
+import { query } from '../database';
+import { Skill } from '../types';
+
+export class SkillsService {
+  async getAll(): Promise<Skill[]> {
+    const result = await query(
+      `SELECT id, name, category, description, created_at as "createdAt", updated_at as "updatedAt" FROM skills ORDER BY name`
+    );
+    return result.rows;
+  }
+
+  async getById(id: string): Promise<Skill | null> {
+    const result = await query(
+      `SELECT id, name, category, description, created_at as "createdAt", updated_at as "updatedAt" FROM skills WHERE id = $1`,
+      [id]
+    );
+    return result.rows[0] || null;
+  }
+
+  async create(data: Omit<Skill, 'id' | 'createdAt' | 'updatedAt'>): Promise<Skill> {
+    const result = await query(
+      `INSERT INTO skills (name, category, description) VALUES ($1,$2,$3) RETURNING id, name, category, description, created_at as "createdAt", updated_at as "updatedAt"`,
+      [data.name, data.category, data.description]
+    );
+    return result.rows[0];
+  }
+
+  async update(
+    id: string,
+    data: Partial<Omit<Skill, 'id' | 'createdAt' | 'updatedAt'>>
+  ): Promise<Skill | null> {
+    const fields: string[] = [];
+    const values: any[] = [];
+    let idx = 1;
+    if (data.name !== undefined) {
+      fields.push(`name = $${idx++}`);
+      values.push(data.name);
+    }
+    if (data.category !== undefined) {
+      fields.push(`category = $${idx++}`);
+      values.push(data.category);
+    }
+    if (data.description !== undefined) {
+      fields.push(`description = $${idx++}`);
+      values.push(data.description);
+    }
+    if (fields.length === 0) return this.getById(id);
+    values.push(id);
+    const result = await query(
+      `UPDATE skills SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = $${idx} RETURNING id, name, category, description, created_at as "createdAt", updated_at as "updatedAt"`,
+      values
+    );
+    return result.rows[0] || null;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const result = await query(`DELETE FROM skills WHERE id = $1`, [id]);
+    return result.rowCount > 0;
+  }
+}
+
+export default SkillsService;

--- a/src/lib/services/user-skills.service.ts
+++ b/src/lib/services/user-skills.service.ts
@@ -1,0 +1,131 @@
+import { query } from '../database';
+import { UserSkill } from '../types';
+import { PointEntriesService } from './point-entries.service';
+
+const SKILL_AWARD_DEFAULT = 50;
+
+export class UserSkillsService {
+  private pointEntries = new PointEntriesService();
+
+  private mapRow(row: any): UserSkill {
+    return {
+      id: row.id,
+      userId: row.user_id,
+      skillId: row.skill_id,
+      level: row.level,
+      verified: row.verified,
+      verifiedBy: row.verified_by,
+      verifiedDate: row.verified_date,
+      requestedVerification: row.requested_verification,
+      isExclusive: row.is_exclusive,
+      notes: row.notes,
+      pointsAwarded: row.points_awarded,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+    };
+  }
+
+  async getAll(): Promise<UserSkill[]> {
+    const result = await query(
+      `SELECT id, user_id, skill_id, level, verified, verified_by, verified_date, requested_verification, is_exclusive, notes, points_awarded, created_at, updated_at FROM user_skills`
+    );
+    return result.rows.map((r: any) => this.mapRow(r));
+  }
+
+  async getById(id: string): Promise<UserSkill | null> {
+    const result = await query(
+      `SELECT id, user_id, skill_id, level, verified, verified_by, verified_date, requested_verification, is_exclusive, notes, points_awarded, created_at, updated_at FROM user_skills WHERE id = $1`,
+      [id]
+    );
+    return result.rows[0] ? this.mapRow(result.rows[0]) : null;
+  }
+
+  async create(data: {
+    userId: string;
+    skillId: string;
+    level: string;
+    isExclusive?: boolean;
+    notes?: string;
+  }): Promise<UserSkill> {
+    const result = await query(
+      `INSERT INTO user_skills (user_id, skill_id, level, is_exclusive, notes) VALUES ($1,$2,$3,$4,$5) RETURNING id, user_id, skill_id, level, verified, verified_by, verified_date, requested_verification, is_exclusive, notes, points_awarded, created_at, updated_at`,
+      [data.userId, data.skillId, data.level, data.isExclusive || false, data.notes || null]
+    );
+    return this.mapRow(result.rows[0]);
+  }
+
+  async update(id: string, updates: Partial<UserSkill>): Promise<UserSkill | null> {
+    const fields: string[] = [];
+    const values: any[] = [];
+    let idx = 1;
+    if (updates.level !== undefined) {
+      fields.push(`level = $${idx++}`);
+      values.push(updates.level);
+    }
+    if (updates.verified !== undefined) {
+      fields.push(`verified = $${idx++}`);
+      values.push(updates.verified);
+    }
+    if (updates.verifiedBy !== undefined) {
+      fields.push(`verified_by = $${idx++}`);
+      values.push(updates.verifiedBy);
+    }
+    if (updates.verifiedDate !== undefined) {
+      fields.push(`verified_date = $${idx++}`);
+      values.push(updates.verifiedDate);
+    }
+    if (updates.requestedVerification !== undefined) {
+      fields.push(`requested_verification = $${idx++}`);
+      values.push(updates.requestedVerification);
+    }
+    if (updates.isExclusive !== undefined) {
+      fields.push(`is_exclusive = $${idx++}`);
+      values.push(updates.isExclusive);
+    }
+    if (updates.notes !== undefined) {
+      fields.push(`notes = $${idx++}`);
+      values.push(updates.notes);
+    }
+    if (updates.pointsAwarded !== undefined) {
+      fields.push(`points_awarded = $${idx++}`);
+      values.push(updates.pointsAwarded);
+    }
+    if (fields.length === 0) return this.getById(id);
+    values.push(id);
+    const result = await query(
+      `UPDATE user_skills SET ${fields.join(', ')}, updated_at = CURRENT_TIMESTAMP WHERE id = $${idx} RETURNING id, user_id, skill_id, level, verified, verified_by, verified_date, requested_verification, is_exclusive, notes, points_awarded, created_at, updated_at`,
+      values
+    );
+    return result.rows[0] ? this.mapRow(result.rows[0]) : null;
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const result = await query(`DELETE FROM user_skills WHERE id = $1`, [id]);
+    return result.rowCount > 0;
+  }
+
+  async verify(id: string, verifierId: string, approve: boolean): Promise<UserSkill | null> {
+    const existing = await this.getById(id);
+    if (!existing) return null;
+    if (!approve) {
+      return this.update(id, { requestedVerification: false });
+    }
+    const updated = await this.update(id, {
+      verified: true,
+      verifiedBy: verifierId,
+      verifiedDate: new Date().toISOString().split('T')[0],
+      requestedVerification: false,
+      pointsAwarded: existing.verified ? existing.pointsAwarded : SKILL_AWARD_DEFAULT,
+    });
+    if (updated && !existing.verified) {
+      await this.pointEntries.create({
+        userId: existing.userId,
+        points: SKILL_AWARD_DEFAULT,
+        reason: 'Skill verification',
+      });
+    }
+    return updated;
+  }
+}
+
+export default UserSkillsService;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -126,3 +126,36 @@ export interface AuthContextType extends AuthState {
   logout: () => void;
   clearError: () => void;
 }
+
+export interface Skill {
+  id: string;
+  name: string;
+  category: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface UserSkill {
+  id: string;
+  userId: string;
+  skillId: string;
+  level: 'basic' | 'proficient' | 'expert';
+  verified: boolean;
+  verifiedBy?: string;
+  verifiedDate?: string;
+  requestedVerification: boolean;
+  isExclusive?: boolean;
+  notes?: string;
+  pointsAwarded?: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface PointEntry {
+  id: string;
+  userId: string;
+  points: number;
+  reason?: string;
+  createdAt: string;
+}

--- a/src/routes/skills.ts
+++ b/src/routes/skills.ts
@@ -1,0 +1,72 @@
+import { Router } from 'express';
+import { SkillsService, UserSkillsService } from '../lib/services';
+
+const router = Router();
+const skillsService = new SkillsService();
+const userSkillsService = new UserSkillsService();
+
+// Skill CRUD
+router.get('/skills', async (_req, res) => {
+  const skills = await skillsService.getAll();
+  res.json(skills);
+});
+
+router.post('/skills', async (req, res) => {
+  const skill = await skillsService.create(req.body);
+  res.status(201).json(skill);
+});
+
+router.get('/skills/:id', async (req, res) => {
+  const skill = await skillsService.getById(req.params.id);
+  if (skill) res.json(skill);
+  else res.sendStatus(404);
+});
+
+router.put('/skills/:id', async (req, res) => {
+  const skill = await skillsService.update(req.params.id, req.body);
+  if (skill) res.json(skill);
+  else res.sendStatus(404);
+});
+
+router.delete('/skills/:id', async (req, res) => {
+  const success = await skillsService.delete(req.params.id);
+  res.sendStatus(success ? 204 : 404);
+});
+
+// User skill CRUD
+router.get('/user-skills', async (_req, res) => {
+  const userSkills = await userSkillsService.getAll();
+  res.json(userSkills);
+});
+
+router.post('/user-skills', async (req, res) => {
+  const userSkill = await userSkillsService.create(req.body);
+  res.status(201).json(userSkill);
+});
+
+router.get('/user-skills/:id', async (req, res) => {
+  const userSkill = await userSkillsService.getById(req.params.id);
+  if (userSkill) res.json(userSkill);
+  else res.sendStatus(404);
+});
+
+router.put('/user-skills/:id', async (req, res) => {
+  const userSkill = await userSkillsService.update(req.params.id, req.body);
+  if (userSkill) res.json(userSkill);
+  else res.sendStatus(404);
+});
+
+router.delete('/user-skills/:id', async (req, res) => {
+  const success = await userSkillsService.delete(req.params.id);
+  res.sendStatus(success ? 204 : 404);
+});
+
+// Verification
+router.post('/user-skills/:id/verify', async (req, res) => {
+  const { approve, verifierId } = req.body;
+  const userSkill = await userSkillsService.verify(req.params.id, verifierId, approve);
+  if (userSkill) res.json(userSkill);
+  else res.sendStatus(404);
+});
+
+export default router;

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -1,0 +1,5 @@
+declare module 'express' {
+  export function Router(): any;
+  const anyExport: any;
+  export default anyExport;
+}


### PR DESCRIPTION
## Summary
- add tables for skills, user skill assignments, and point entries with updated triggers
- implement services and routes to manage skills, user skills, and verification awarding points
- enhance skills page to request verification, review, and deny without affecting budget

## Testing
- `npm run build` (fails: Cannot find module '@rollup/rollup-linux-x64-gnu')

------
https://chatgpt.com/codex/tasks/task_e_68ad0ff9ac0883298cfb2c4f5f6c1ae5