### PR TITLE
feat: add i18n and locale-aware utilities

### DIFF
--- a/src/components/layout/app-layout.tsx
+++ b/src/components/layout/app-layout.tsx
@@ -170,7 +170,8 @@ export function AppLayout({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm">
-                  <Globe className="size-4" />
+                  <Globe className="size-4 mr-1" />
+                  <span className="uppercase">{currentLanguage}</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">

--- a/src/components/layout/enhanced-app-layout.tsx
+++ b/src/components/layout/enhanced-app-layout.tsx
@@ -297,7 +297,8 @@ export function EnhancedAppLayout({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="sm">
-                  <Globe className="size-4" />
+                  <Globe className="size-4 mr-1" />
+                  <span className="uppercase">{currentLanguage}</span>
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">

--- a/src/components/pages/dashboard.tsx
+++ b/src/components/pages/dashboard.tsx
@@ -37,6 +37,7 @@ import { tasks, users } from '../../lib/data';
 import { getUnreadCount } from '../../lib/notifications-data';
 import { Task, User as UserType } from '../../lib/types';
 import { useCurrentUser } from '../../lib/hooks/use-current-user';
+import { useTranslations } from '../../lib/hooks/use-translations';
 
 interface DashboardProps {
   onTaskClick: (task: Task) => void;
@@ -66,6 +67,7 @@ export function Dashboard({
   onGetHelp
 }: DashboardProps) {
   const { user: currentUser, isLoading } = useCurrentUser();
+  const { t } = useTranslations();
   const [currentTime, setCurrentTime] = useState(new Date());
   const [salesData, setSalesData] = useState({
     today: 2675.50,
@@ -82,7 +84,7 @@ export function Dashboard({
 
   // Safety check for currentUser
   if (isLoading || !currentUser) {
-    return <div>Loading...</div>;
+    return <div>{t('loading')}</div>;
   }
 
   const isManagement = currentUser.roles.some(role => 
@@ -122,15 +124,15 @@ export function Dashboard({
 
   // Quick actions based on role
   const quickActions = isManagement ? [
-    { id: 'new-order', label: 'New Order', icon: Package, action: onNewOrder, color: 'primary' },
-    { id: 'cash-count', label: 'Cash Count', icon: Wallet, action: onCashCount, color: 'warning' },
-    { id: 'staff-meal', label: 'Staff Meal', icon: Utensils, action: onStaffMeal, color: 'success' },
-    { id: 'issue-report', label: 'Report Issue', icon: AlertTriangle, action: onReportIssue, color: 'destructive' }
+    { id: 'new-order', label: t('newOrder'), icon: Package, action: onNewOrder, color: 'primary' },
+    { id: 'cash-count', label: t('cashCount'), icon: Wallet, action: onCashCount, color: 'warning' },
+    { id: 'staff-meal', label: t('staffMeal'), icon: Utensils, action: onStaffMeal, color: 'success' },
+    { id: 'issue-report', label: t('reportIssue'), icon: AlertTriangle, action: onReportIssue, color: 'destructive' }
   ] : [
-    { id: 'clock-in', label: 'Clock In/Out', icon: Clock, action: onClockIn, color: 'primary' },
-    { id: 'staff-meal', label: 'Request Meal', icon: Utensils, action: onRequestMeal, color: 'success' },
-    { id: 'break', label: 'Take Break', icon: Coffee, action: onTakeBreak, color: 'secondary' },
-    { id: 'help', label: 'Get Help', icon: AlertCircle, action: onGetHelp, color: 'outline' }
+    { id: 'clock-in', label: t('clockInOut'), icon: Clock, action: onClockIn, color: 'primary' },
+    { id: 'staff-meal', label: t('requestMeal'), icon: Utensils, action: onRequestMeal, color: 'success' },
+    { id: 'break', label: t('takeBreak'), icon: Coffee, action: onTakeBreak, color: 'secondary' },
+    { id: 'help', label: t('getHelp'), icon: AlertCircle, action: onGetHelp, color: 'outline' }
   ];
 
   // Staff performance data

--- a/src/components/pages/login.tsx
+++ b/src/components/pages/login.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useAuth } from '../../lib/contexts/auth-context';
+import { useTranslations } from '../../lib/hooks/use-translations';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
@@ -14,8 +15,9 @@ export function LoginPage() {
   const [password, setPassword] = useState('');
   const [showPassword, setShowPassword] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  
+
   const { login, error, clearError, isLoading } = useAuth();
+  const { t } = useTranslations();
 
   // Clear error when component mounts or when error changes
   useEffect(() => {
@@ -28,7 +30,7 @@ export function LoginPage() {
     e.preventDefault();
     
     if (!email || !password) {
-      toast.error('Please fill in all fields');
+      toast.error(t('pleaseFillAllFields'));
       return;
     }
 
@@ -37,12 +39,12 @@ export function LoginPage() {
     try {
       const success = await login({ email, password });
       if (success) {
-        toast.success('Login successful! Welcome back.');
+        toast.success(t('loginSuccessful'));
       } else {
-        toast.error('Login failed. Please check your credentials.');
+        toast.error(t('loginFailed'));
       }
     } catch (error) {
-      toast.error('An unexpected error occurred.');
+      toast.error(t('unexpectedError'));
     } finally {
       setIsSubmitting(false);
     }
@@ -53,10 +55,10 @@ export function LoginPage() {
     try {
       const success = await login({ email: demoEmail, password: 'password123' });
       if (success) {
-        toast.success('Demo login successful!');
+        toast.success(t('demoLoginSuccessful'));
       }
     } catch (error) {
-      toast.error('Demo login failed.');
+      toast.error(t('demoLoginFailed'));
     } finally {
       setIsSubmitting(false);
     }
@@ -65,7 +67,7 @@ export function LoginPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-orange-50 to-red-50">
-        <LoadingSpinner size="lg" text="Loading..." />
+        <LoadingSpinner size="lg" text={t('loading')} />
       </div>
     );
   }
@@ -79,10 +81,10 @@ export function LoginPage() {
             <ChefHat className="h-8 w-8 text-white" />
           </div>
           <h1 className="text-3xl font-bold text-gray-900 mb-2">
-            Makan Manager
+            {t('appName')}
           </h1>
           <p className="text-gray-600">
-            Restaurant Staff Management System
+            {t('appTagline')}
           </p>
         </div>
 
@@ -90,10 +92,10 @@ export function LoginPage() {
         <Card className="shadow-xl border-0">
           <CardHeader className="text-center pb-4">
             <CardTitle className="text-2xl font-semibold text-gray-900">
-              Welcome Back
+              {t('welcomeBack')}
             </CardTitle>
             <CardDescription className="text-gray-600">
-              Sign in to your account to continue
+              {t('signInToContinue')}
             </CardDescription>
           </CardHeader>
           
@@ -101,12 +103,12 @@ export function LoginPage() {
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="email" className="text-sm font-medium text-gray-700">
-                  Email Address
+                  {t('emailAddress')}
                 </Label>
                 <Input
                   id="email"
                   type="email"
-                  placeholder="Enter your email"
+                  placeholder={t('enterYourEmail')}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   className="h-11"
@@ -116,13 +118,13 @@ export function LoginPage() {
 
               <div className="space-y-2">
                 <Label htmlFor="password" className="text-sm font-medium text-gray-700">
-                  Password
+                  {t('password')}
                 </Label>
                 <div className="relative">
                   <Input
                     id="password"
                     type={showPassword ? 'text' : 'password'}
-                    placeholder="Enter your password"
+                    placeholder={t('enterYourPassword')}
                     value={password}
                     onChange={(e) => setPassword(e.target.value)}
                     className="h-11 pr-10"
@@ -150,10 +152,10 @@ export function LoginPage() {
                 {isSubmitting ? (
                   <>
                     <LoadingSpinner size="sm" />
-                    Signing In...
+                    {t('signingIn')}
                   </>
                 ) : (
-                  'Sign In'
+                  t('signIn')
                 )}
               </Button>
             </form>
@@ -161,7 +163,7 @@ export function LoginPage() {
             {/* Demo Accounts */}
             <div className="pt-4 border-t border-gray-200">
               <p className="text-sm text-gray-600 text-center mb-3">
-                Try demo accounts:
+                {t('tryDemoAccounts')}
               </p>
               <div className="grid grid-cols-2 gap-2">
                 <Button
@@ -171,7 +173,7 @@ export function LoginPage() {
                   disabled={isSubmitting}
                   className="text-xs"
                 >
-                  Owner (Jay)
+                  {t('owner')} (Jay)
                 </Button>
                 <Button
                   variant="outline"
@@ -180,7 +182,7 @@ export function LoginPage() {
                   disabled={isSubmitting}
                   className="text-xs"
                 >
-                  Manager (Simon)
+                  {t('manager')} (Simon)
                 </Button>
                 <Button
                   variant="outline"
@@ -189,7 +191,7 @@ export function LoginPage() {
                   disabled={isSubmitting}
                   className="text-xs"
                 >
-                  Kitchen (Lily)
+                  {t('kitchen')} (Lily)
                 </Button>
                 <Button
                   variant="outline"
@@ -198,7 +200,7 @@ export function LoginPage() {
                   disabled={isSubmitting}
                   className="text-xs"
                 >
-                  Staff (Ana)
+                  {t('staff')} (Ana)
                 </Button>
               </div>
             </div>

--- a/src/lib/cash-data.ts
+++ b/src/lib/cash-data.ts
@@ -397,8 +397,11 @@ export const formatCurrency = (amount: number): string => {
   return `RM${amount.toFixed(2)}`;
 };
 
-export const formatDateTime = (dateString: string): string => {
-  return new Date(dateString).toLocaleString('en-US', {
+export const formatDateTime = (
+  dateString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(dateString).toLocaleString(locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -407,8 +410,11 @@ export const formatDateTime = (dateString: string): string => {
   });
 };
 
-export const formatTime = (dateString: string): string => {
-  return new Date(dateString).toLocaleTimeString('en-US', {
+export const formatTime = (
+  dateString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(dateString).toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit'
   });

--- a/src/lib/contexts/language-context.tsx
+++ b/src/lib/contexts/language-context.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, useState, ReactNode } from 'react';
-import { Language, useTranslation } from '../i18n';
+import { Language, useTranslation, languageCodes } from '../i18n';
 
 interface LanguageContextType {
   currentLanguage: Language;
@@ -17,22 +17,21 @@ interface LanguageProviderProps {
 }
 
 export function LanguageProvider({ children, defaultLanguage = 'en' }: LanguageProviderProps) {
-  const [currentLanguage, setCurrentLanguage] = useState<Language>(defaultLanguage);
-  const { t, languageNames, languageCodes } = useTranslation(currentLanguage);
+  const [currentLanguage, setCurrentLanguage] = useState<Language>(() => {
+    if (typeof window !== 'undefined') {
+      const saved = localStorage.getItem('preferredLanguage') as Language;
+      if (saved && (languageCodes as Language[]).includes(saved)) {
+        return saved;
+      }
+    }
+    return defaultLanguage;
+  });
+  const { t, languageNames } = useTranslation(currentLanguage);
 
   const setLanguage = (language: Language) => {
     setCurrentLanguage(language);
-    // Optionally save to localStorage for persistence
     localStorage.setItem('preferredLanguage', language);
   };
-
-  // Load saved language preference on mount
-  React.useEffect(() => {
-    const savedLanguage = localStorage.getItem('preferredLanguage') as Language;
-    if (savedLanguage && languageCodes.includes(savedLanguage)) {
-      setCurrentLanguage(savedLanguage);
-    }
-  }, [languageCodes]);
 
   const value: LanguageContextType = {
     currentLanguage,

--- a/src/lib/hooks/use-translations.ts
+++ b/src/lib/hooks/use-translations.ts
@@ -1,8 +1,8 @@
 import { useLanguage } from '../contexts/language-context';
 
-// Simple translation function that returns the key if no translation is found
+// Translation hook that prefers context translations and falls back to internal defaults
 export function useTranslations() {
-  const { currentLanguage, t, setLanguage, languageNames } = useLanguage();
+  const { currentLanguage, t: contextT, setLanguage, languageNames } = useLanguage();
   
   // Fallback translations for common UI elements
   const fallbackTranslations: Record<string, Record<string, string>> = {
@@ -213,6 +213,10 @@ export function useTranslations() {
   };
 
   const translate = (key: string): string => {
+    const translated = contextT(key as any);
+    if (translated && translated !== key) {
+      return translated;
+    }
     const translations = fallbackTranslations[currentLanguage] || fallbackTranslations.en;
     return translations[key] || key;
   };

--- a/src/lib/i18n/translations/en.ts
+++ b/src/lib/i18n/translations/en.ts
@@ -34,6 +34,27 @@ export const en = {
   next: "Next",
   previous: "Previous",
 
+  // Auth
+  appName: "Makan Manager",
+  appTagline: "Restaurant Staff Management System",
+  signInToContinue: "Sign in to your account to continue",
+  emailAddress: "Email Address",
+  enterYourEmail: "Enter your email",
+  password: "Password",
+  enterYourPassword: "Enter your password",
+  signIn: "Sign In",
+  signingIn: "Signing In...",
+  tryDemoAccounts: "Try demo accounts:",
+  owner: "Owner",
+  manager: "Manager",
+  kitchen: "Kitchen",
+  pleaseFillAllFields: "Please fill in all fields",
+  loginSuccessful: "Login successful! Welcome back.",
+  loginFailed: "Login failed. Please check your credentials.",
+  demoLoginSuccessful: "Demo login successful!",
+  demoLoginFailed: "Demo login failed.",
+  unexpectedError: "An unexpected error occurred.",
+
   // Navigation Groups
   operations: "Operations",
   staffManagement: "Staff Management",
@@ -69,6 +90,13 @@ export const en = {
   createTask: "Create Task",
   viewAllTasks: "View All Tasks",
   viewAllOrders: "View All Orders",
+  newOrder: "New Order",
+  cashCount: "Cash Count",
+  reportIssue: "Report Issue",
+  clockInOut: "Clock In/Out",
+  requestMeal: "Request Meal",
+  takeBreak: "Take Break",
+  getHelp: "Get Help",
 
   // Tasks
   taskTitle: "Task Title",

--- a/src/lib/i18n/translations/id.ts
+++ b/src/lib/i18n/translations/id.ts
@@ -34,6 +34,27 @@ export const id = {
   next: "Selanjutnya",
   previous: "Sebelumnya",
 
+  // Auth
+  appName: "Makan Manager",
+  appTagline: "Sistem Manajemen Staf Restoran",
+  signInToContinue: "Masuk ke akun Anda untuk melanjutkan",
+  emailAddress: "Alamat Email",
+  enterYourEmail: "Masukkan email Anda",
+  password: "Kata Sandi",
+  enterYourPassword: "Masukkan kata sandi Anda",
+  signIn: "Masuk",
+  signingIn: "Sedang Masuk...",
+  tryDemoAccounts: "Coba akun demo:",
+  owner: "Pemilik",
+  manager: "Manajer",
+  kitchen: "Dapur",
+  pleaseFillAllFields: "Silakan isi semua bidang",
+  loginSuccessful: "Berhasil masuk! Selamat datang kembali.",
+  loginFailed: "Gagal masuk. Periksa kredensial Anda.",
+  demoLoginSuccessful: "Login demo berhasil!",
+  demoLoginFailed: "Login demo gagal.",
+  unexpectedError: "Terjadi kesalahan tak terduga.",
+
   // Navigation Groups
   operations: "Operasi",
   staffManagement: "Manajemen Staf",
@@ -69,6 +90,13 @@ export const id = {
   createTask: "Buat Tugas",
   viewAllTasks: "Lihat Semua Tugas",
   viewAllOrders: "Lihat Semua Pesanan",
+  newOrder: "Pesanan Baru",
+  cashCount: "Hitung Kas",
+  reportIssue: "Laporkan Masalah",
+  clockInOut: "Masuk/Keluar",
+  requestMeal: "Minta Makan",
+  takeBreak: "Istirahat",
+  getHelp: "Minta Bantuan",
 
   // Tasks
   taskTitle: "Judul Tugas",

--- a/src/lib/i18n/translations/my.ts
+++ b/src/lib/i18n/translations/my.ts
@@ -34,6 +34,27 @@ export const my = {
   next: "ရှေ့သို့",
   previous: "နောက်သို့",
 
+  // Auth
+  appName: "Makan Manager",
+  appTagline: "စားသောက်ဆိုင်ဝန်ထမ်းစီမံခန့်ခွဲမှုစနစ်",
+  signInToContinue: "သင့်အကောင့်သို့ဝင်ရောက်ပြီး ဆက်လက်အသုံးပြုပါ",
+  emailAddress: "အီးမေးလ်လိပ်စာ",
+  enterYourEmail: "သင်၏အီးမေးလ်ထည့်ပါ",
+  password: "စကားဝှက်",
+  enterYourPassword: "သင့်စကားဝှက်ထည့်ပါ",
+  signIn: "ဝင်ရောက်မည်",
+  signingIn: "ဝင်ရောက်နေသည်...",
+  tryDemoAccounts: "ဒေမိုအကောင့်များစမ်းပါ:",
+  owner: "ပိုင်ရှင်",
+  manager: "မန်နေဂျာ",
+  kitchen: "မီးဖိုချောင်",
+  pleaseFillAllFields: "ကျေးဇူးပြု၍ အချက်အလက်အားလုံးဖြည့်ပါ",
+  loginSuccessful: "ဝင်ရောက်မှုအောင်မြင်ပါသည်! ကြိုဆိုပါသည်။",
+  loginFailed: "ဝင်ရောက်မှုမအောင်မြင်ပါ။ အချက်အလက်များစစ်ဆေးပါ။",
+  demoLoginSuccessful: "ဒေမိုဝင်ရောက်မှုအောင်မြင်ပါသည်!",
+  demoLoginFailed: "ဒေမိုဝင်ရောက်မှုမအောင်မြင်ပါ။",
+  unexpectedError: "မမျှော်လင့်ထားသော အမှားအယွင်း ဖြစ်ပေါ်ခဲ့သည်။",
+
   // Dashboard
   welcomeBack: "ပြန်လည်ကြိုဆိုပါတယ်",
   todayTasks: "ယနေ့၏လုပ်ငန်းတာဝန်များ",
@@ -42,6 +63,13 @@ export const my = {
   createTask: "လုပ်ငန်းတာဝန်ဖန်တီးရန်",
   viewAllTasks: "လုပ်ငန်းတာဝန်အားလုံးကြည့်ရန်",
   viewAllOrders: "အော်ဒါအားလုံးကြည့်ရန်",
+  newOrder: "အော်ဒါအသစ်",
+  cashCount: "ငွေစာရင်း",
+  reportIssue: "ပြဿနာတင်ပြရန်",
+  clockInOut: "အလုပ်ဝင်/ထွက်",
+  requestMeal: "အစားအစာ တောင်းခံရန်",
+  takeBreak: "နားရန်",
+  getHelp: "အကူအညီရယူရန်",
 
   // Tasks
   taskTitle: "လုပ်ငန်းတာဝန်၏ခေါင်းစဉ်",

--- a/src/lib/i18n/translations/vi.ts
+++ b/src/lib/i18n/translations/vi.ts
@@ -34,6 +34,27 @@ export const vi = {
   next: "Tiếp theo",
   previous: "Trước đó",
 
+  // Auth
+  appName: "Makan Manager",
+  appTagline: "Hệ thống quản lý nhân viên nhà hàng",
+  signInToContinue: "Đăng nhập vào tài khoản của bạn để tiếp tục",
+  emailAddress: "Địa chỉ Email",
+  enterYourEmail: "Nhập email của bạn",
+  password: "Mật khẩu",
+  enterYourPassword: "Nhập mật khẩu của bạn",
+  signIn: "Đăng nhập",
+  signingIn: "Đang đăng nhập...",
+  tryDemoAccounts: "Thử tài khoản demo:",
+  owner: "Chủ",
+  manager: "Quản lý",
+  kitchen: "Bếp",
+  pleaseFillAllFields: "Vui lòng điền vào tất cả các trường",
+  loginSuccessful: "Đăng nhập thành công! Chào mừng trở lại.",
+  loginFailed: "Đăng nhập thất bại. Vui lòng kiểm tra thông tin.",
+  demoLoginSuccessful: "Đăng nhập demo thành công!",
+  demoLoginFailed: "Đăng nhập demo thất bại.",
+  unexpectedError: "Đã xảy ra lỗi bất ngờ.",
+
   // Dashboard
   welcomeBack: "Chào mừng trở lại",
   todayTasks: "Nhiệm vụ hôm nay",
@@ -42,6 +63,13 @@ export const vi = {
   createTask: "Tạo nhiệm vụ",
   viewAllTasks: "Xem tất cả nhiệm vụ",
   viewAllOrders: "Xem tất cả đơn hàng",
+  newOrder: "Đơn mới",
+  cashCount: "Kiểm tiền",
+  reportIssue: "Báo cáo vấn đề",
+  clockInOut: "Chấm công",
+  requestMeal: "Yêu cầu bữa ăn",
+  takeBreak: "Nghỉ giải lao",
+  getHelp: "Nhận trợ giúp",
 
   // Tasks
   taskTitle: "Tiêu đề nhiệm vụ",

--- a/src/lib/notifications-data.ts
+++ b/src/lib/notifications-data.ts
@@ -363,9 +363,12 @@ export const formatTimeAgo = (timestamp: string): string => {
   return time.toLocaleDateString();
 };
 
-export const formatNotificationTime = (timestamp: string): string => {
+export const formatNotificationTime = (
+  timestamp: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
   const time = new Date(timestamp);
-  return time.toLocaleTimeString('en-US', {
+  return time.toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit'
   });

--- a/src/lib/online-orders-data.ts
+++ b/src/lib/online-orders-data.ts
@@ -605,8 +605,11 @@ export const formatCurrency = (amount: number): string => {
   return `RM${amount.toFixed(2)}`;
 };
 
-export const formatDateTime = (dateString: string): string => {
-  return new Date(dateString).toLocaleString('en-US', {
+export const formatDateTime = (
+  dateString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(dateString).toLocaleString(locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -615,8 +618,11 @@ export const formatDateTime = (dateString: string): string => {
   });
 };
 
-export const formatTime = (dateString: string): string => {
-  return new Date(dateString).toLocaleTimeString('en-US', {
+export const formatTime = (
+  dateString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(dateString).toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit'
   });

--- a/src/lib/operations-data.ts
+++ b/src/lib/operations-data.ts
@@ -1140,8 +1140,11 @@ export const formatCurrency = (amount: number): string => {
   return `RM${amount.toFixed(2)}`;
 };
 
-export const formatDateTime = (dateString: string): string => {
-  return new Date(dateString).toLocaleString("en-US", {
+export const formatDateTime = (
+  dateString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(dateString).toLocaleString(locale, {
     year: "numeric",
     month: "short",
     day: "numeric",

--- a/src/lib/salary-data.ts
+++ b/src/lib/salary-data.ts
@@ -641,8 +641,11 @@ export const formatCurrency = (amount: number): string => {
   return `RM${amount.toFixed(2)}`;
 };
 
-export const formatDateTime = (dateString: string): string => {
-  return new Date(dateString).toLocaleString('en-US', {
+export const formatDateTime = (
+  dateString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(dateString).toLocaleString(locale, {
     year: 'numeric',
     month: 'short',
     day: 'numeric',
@@ -651,8 +654,11 @@ export const formatDateTime = (dateString: string): string => {
   });
 };
 
-export const formatTime = (timeString: string): string => {
-  return new Date(`2024-01-01T${timeString}`).toLocaleTimeString('en-US', {
+export const formatTime = (
+  timeString: string,
+  locale: string = typeof navigator !== 'undefined' ? navigator.language : 'en-US'
+): string => {
+  return new Date(`2024-01-01T${timeString}`).toLocaleTimeString(locale, {
     hour: '2-digit',
     minute: '2-digit',
     hour12: true


### PR DESCRIPTION
## Summary
- localize login and dashboard quick actions using translation keys
- persist language preference and expose current language in header
- make date/time utilities locale-aware

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_68ad100751b883298dc9da03b937dd74