### PR TITLE
Add report metrics aggregation and export endpoints

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -47,6 +47,13 @@ export interface Task {
   rejectionReason?: string;
 }
 
+export interface ReportMetrics {
+  tasksOnTimePercent: number;
+  spending: number;
+  budget: number;
+  budgetUtilization: number;
+}
+
 export interface DisciplinaryAction {
   id: string;
   targetUserId: string;


### PR DESCRIPTION
## Summary
- add `/api/reports/metrics` for task on-time percentages and budget utilization
- add CSV exports for top performers and spending
- generate monthly PDF report with jsPDF

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc -p tsconfig.json --noEmit` *(fails: Referenced project may not disable emit)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1016ffb88329842ddc46dd4dd675