### PR TITLE
feat: support offline reminders via service worker

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -11,16 +11,22 @@ const TRANSLATION_ASSETS = [
 ];
 
 self.addEventListener('install', (event) => {
+  self.skipWaiting();
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) => cache.addAll([...APP_SHELL, ...TRANSLATION_ASSETS]))
+    caches
+      .open(CACHE_NAME)
+      .then((cache) => cache.addAll([...APP_SHELL, ...TRANSLATION_ASSETS]))
   );
 });
 
 self.addEventListener('activate', (event) => {
   event.waitUntil(
-    caches.keys().then((keys) =>
-      Promise.all(keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : null)))
-    )
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.map((key) => (key !== CACHE_NAME ? caches.delete(key) : null)))
+      )
+      .then(() => self.clients.claim())
   );
 });
 

--- a/src/lib/notifications.ts
+++ b/src/lib/notifications.ts
@@ -20,6 +20,11 @@ interface ReminderOptions {
 
 export async function scheduleReminder(options: ReminderOptions) {
   if (!('serviceWorker' in navigator)) return;
+  if (Notification.permission !== 'granted') {
+    const granted = await requestNotificationPermission();
+    if (!granted) return;
+  }
+
   const registration = await navigator.serviceWorker.ready;
   registration.active?.postMessage({
     type: 'schedule-reminder',

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,20 @@
-
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 import { requestNotificationPermission } from "./lib/notifications";
 
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register('/sw.js');
+  window.addEventListener('load', async () => {
+    try {
+      await navigator.serviceWorker.register('/sw.js');
+      await requestNotificationPermission();
+    } catch (e) {
+      console.error('Service worker registration failed', e);
+    }
   });
+} else {
+  requestNotificationPermission();
 }
-
-requestNotificationPermission();
 
 createRoot(document.getElementById("root")!).render(<App />);
   


### PR DESCRIPTION
## Summary
- cache app shell and translations in service worker
- request notification permissions and schedule offline reminders
- register service worker and notification permission on app load

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Transform failed in App.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1ea8b1d88329afe2e7872d453360