### PR TITLE
feat: add session-based auth with RBAC

### DIFF
--- a/server/middleware/rbac.js
+++ b/server/middleware/rbac.js
@@ -1,0 +1,69 @@
+// Role-based access control middleware
+// Uses in-memory sessions and users stored on app.locals
+
+const rolePermissions = {
+  owner: ['view_users', 'manage_users', 'manage_issues', 'view_reports'],
+  manager: ['manage_issues', 'view_reports'],
+  'head-of-kitchen': ['manage_issues'],
+  staff: [],
+};
+
+function authenticate(req, res, next) {
+  const header = req.headers['x-session-id'] || req.headers['authorization'];
+  const sessionId = header && header.startsWith('Bearer ')
+    ? header.slice(7)
+    : header;
+
+  if (!sessionId) {
+    return res.status(401).json({ message: 'No session provided' });
+  }
+
+  const sessions = req.app.locals.sessions;
+  const users = req.app.locals.users;
+  const session = sessions.get(sessionId);
+  if (!session || session.expiresAt < Date.now()) {
+    sessions.delete(sessionId);
+    return res.status(401).json({ message: 'Invalid session' });
+  }
+
+  const user = users.find((u) => u.id === session.userId);
+  if (!user) {
+    sessions.delete(sessionId);
+    return res.status(401).json({ message: 'Invalid session' });
+  }
+
+  // Refresh session TTL
+  session.expiresAt = Date.now() + req.app.locals.sessionTTL;
+  req.user = user;
+  next();
+}
+
+function requireRole(...roles) {
+  return (req, res, next) => {
+    if (!req.user || !req.user.roles.some((r) => roles.includes(r))) {
+      return res.status(403).json({ message: 'Insufficient role' });
+    }
+    next();
+  };
+}
+
+function requirePermission(permission) {
+  return (req, res, next) => {
+    const userRoles = req.user ? req.user.roles : [];
+    const hasPermission = userRoles.some((role) =>
+      (rolePermissions[role] || []).includes(permission)
+    );
+    if (!hasPermission) {
+      return res.status(403).json({ message: 'Insufficient permission' });
+    }
+    next();
+  };
+}
+
+module.exports = {
+  authenticate,
+  requireRole,
+  requirePermission,
+  rolePermissions,
+};
+

--- a/src/lib/contexts/auth-context.tsx
+++ b/src/lib/contexts/auth-context.tsx
@@ -78,37 +78,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   // Initialize authentication on mount
   useEffect(() => {
-    const initAuth = () => {
+    const initAuth = async () => {
       try {
-        console.log('Initializing authentication...');
-        const storedUser = AuthService.getStoredUser();
-        console.log('Stored user:', storedUser);
-        
-        // For development: auto-login with default user if no stored user
-        if (!storedUser) {
-          const defaultUser = {
-            id: '1',
-            name: 'Jay',
-            email: 'jay@makanmanager.com',
-            password: 'password123',
-            roles: ['owner' as const],
-            avatar: '👨‍💼',
-            phone: '+60123456789',
-            startDate: '2020-01-15',
-            emergencyContact: '+60123456790',
-            photo: 'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=100&h=100&fit=crop&crop=face',
-            station: 'front' as const,
-            points: 2500,
-            weeklyPoints: 350,
-            monthlyPoints: 1200
-          };
-          AuthService.storeUser(defaultUser);
-          dispatch({ type: 'INIT_AUTH', payload: defaultUser });
+        const result = await AuthService.validateSession();
+        if (result.valid && result.user) {
+          dispatch({ type: 'INIT_AUTH', payload: result.user });
         } else {
-          dispatch({ type: 'INIT_AUTH', payload: storedUser });
+          dispatch({ type: 'INIT_AUTH', payload: null });
         }
       } catch (error) {
-        console.error('Error initializing auth:', error);
         dispatch({ type: 'INIT_AUTH', payload: null });
       }
     };

--- a/src/lib/services/auth.service.ts
+++ b/src/lib/services/auth.service.ts
@@ -1,7 +1,6 @@
 import { LoginCredentials, User } from '../types';
 
-const ACCESS_KEY = 'makanmanager_access_token';
-const REFRESH_KEY = 'makanmanager_refresh_token';
+const SESSION_KEY = 'makanmanager_session_id';
 
 export class AuthService {
   static async login(
@@ -23,12 +22,8 @@ export class AuthService {
       }
 
       const data = await response.json();
-      if (data.accessToken) {
-        localStorage.setItem(ACCESS_KEY, data.accessToken);
-      }
-      if (data.refreshToken) {
-        localStorage.setItem(REFRESH_KEY, data.refreshToken);
-
+      if (data.sessionId) {
+        localStorage.setItem(SESSION_KEY, data.sessionId);
       }
 
       return { success: true, user: data.user };
@@ -37,9 +32,9 @@ export class AuthService {
     }
   }
 
-  static async validateToken(): Promise<{ valid: boolean; user?: User }> {
-    const refreshToken = localStorage.getItem(REFRESH_KEY);
-    if (!refreshToken) {
+  static async validateSession(): Promise<{ valid: boolean; user?: User }> {
+    const sessionId = localStorage.getItem(SESSION_KEY);
+    if (!sessionId) {
       return { valid: false };
     }
 
@@ -49,7 +44,7 @@ export class AuthService {
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ refreshToken }),
+        body: JSON.stringify({ sessionId }),
       });
 
       if (!response.ok) {
@@ -57,9 +52,6 @@ export class AuthService {
       }
 
       const data = await response.json();
-      if (data.accessToken) {
-        localStorage.setItem(ACCESS_KEY, data.accessToken);
-      }
       if (data.user) {
         AuthService.storeUser(data.user);
         return { valid: true, user: data.user };
@@ -72,22 +64,21 @@ export class AuthService {
   }
 
   static async logout(): Promise<void> {
-    const refreshToken = localStorage.getItem(REFRESH_KEY);
+    const sessionId = localStorage.getItem(SESSION_KEY);
 
     try {
-      if (refreshToken) {
+      if (sessionId) {
         await fetch('/api/auth/logout', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ refreshToken }),
+          body: JSON.stringify({ sessionId }),
         });
       }
     } finally {
       localStorage.removeItem('makanmanager_user');
-      localStorage.removeItem(ACCESS_KEY);
-      localStorage.removeItem(REFRESH_KEY);
+      localStorage.removeItem(SESSION_KEY);
     }
   }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -10,7 +10,7 @@ export interface User {
   id: string;
   name: string;
   email: string;
-  password: string; // In production, this should be hashed
+  password?: string; // Not returned by the authentication API
   roles: UserRole[];
   avatar?: string;
   gender: 'male' | 'female';


### PR DESCRIPTION
## Summary
- switch auth server to salted password hashing with expiring sessions
- add middleware for role and permission checks
- update React auth context/service to use session backend

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68ad1f25b6008329b1b6fa771ed57352